### PR TITLE
Fix check-dnf for Fedora 41 / dnf5.

### DIFF
--- a/linux_files/check-dnf
+++ b/linux_files/check-dnf
@@ -1,7 +1,7 @@
 #! /bin/bash
 
-gpgcheck_enabled=$(dnf config-manager --dump '*' | grep -c "gpgcheck = 1")
+gpgcheck_enabled=$(grep -E "^\s*gpgcheck\s*=\s*1" /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo)
 
-if [[ ${gpgcheck_enabled} -ge 0 ]]; then
-  dnf config-manager --save --setopt=*.gpgcheck=0
+if [ -n "${gpgcheck_enabled}" ]; then
+  sed -i -e 's/^\s*gpgcheck\s*=\s*1\s*$/gpgcheck=0/' /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo
 fi

--- a/linux_files/check-dnf
+++ b/linux_files/check-dnf
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-gpgcheck_enabled=$(grep -E "^\s*gpgcheck\s*=\s*1" /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo)
+gpgcheck_enabled=$(grep -E "^\s*gpgcheck\s*=\s*1\s*$" /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo)
 
 if [ -n "${gpgcheck_enabled}" ]; then
   sed -i -e 's/^\s*gpgcheck\s*=\s*1\s*$/gpgcheck=0/' /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo

--- a/linux_files/check-dnf
+++ b/linux_files/check-dnf
@@ -1,6 +1,10 @@
 #! /bin/bash
 
-gpgcheck_enabled=$(grep -E "^\s*gpgcheck\s*=\s*1\s*$" /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo)
+if [ -f /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo ]; then
+  gpgcheck_enabled=$(grep -E "^\s*gpgcheck\s*=\s*1\s*$" /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo)
+else
+  gpgcheck_enabled=""
+fi
 
 if [ -n "${gpgcheck_enabled}" ]; then
   sed -i -e 's/^\s*gpgcheck\s*=\s*1\s*$/gpgcheck=0/' /etc/yum.repos.d/whitewaterfoundry_fedoraremix.repo


### PR DESCRIPTION
Fixes https://github.com/WhitewaterFoundry/Fedora-Remix-for-WSL/issues/235.

All the other repos are working OK with gpgcheck on, better to leave it on if possible.

The dnf5 stuff didn't want to work for me.  Returned 0 but didn't update the file / repos.